### PR TITLE
Bump to version 0.1.0

### DIFF
--- a/lib/ruby-bbcode-to-md/version.rb
+++ b/lib/ruby-bbcode-to-md/version.rb
@@ -1,3 +1,3 @@
 module RubyBbcode
-  VERSION = "0.0.14"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
Thanks for merging https://github.com/rikkit/ruby-bbcode-to-md/pull/5 . This is a version bump to go with those changes. Perhaps I should have included it in that PR, but I didn't want to complicate it.

Since those changes were from back in 2016, back when other commits were happening here, it's seems like a good time to stop with the patch increments and call it 0.1.0 (or even 1.0.0 if you want to go crazy)